### PR TITLE
Fix display of <th> elements, "State" column and finish line circle

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1364,7 +1364,7 @@ var controller = function () {
                         + recordRaceFields(race, r)
                         + Util.gentd("Position","",null, (r.pos ? Util.formatPosition(r.pos.lat, r.pos.lon) : "-") )
                         + Util.gentd("Options","",xOptionsTitle, xOptionsTxt)
-                        + Util.gentd("State",null, 'title="' + txtTitle + '"', iconState )
+                        + Util.gentd("State", "", txtTitle, iconState)
                         + '</tr>';
                 }
             }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1359,7 +1359,7 @@ var controller = function () {
                         + Util.gentd("Sail","",null, '<span ' + bi.sailStyle + '>&#x25e2&#x25e3  </span>' + bi.sSail )
                         + Util.gentd("Sail","",null,  bi.aSail )
                         + Util.gentd("Factor", bi.xfactorStyle,null, xfactorTxt )
-                        + Util.gentd("Foils", null,null, (r.xoption_foils || "?") )
+                        + Util.gentd("Foils", "", null, (r.xoption_foils || "?"))
                         + Util.gentd("Stamina",bi.staminaStyle,null,staminaTxt)  
                         + recordRaceFields(race, r)
                         + Util.gentd("Position","",null, (r.pos ? Util.formatPosition(r.pos.lat, r.pos.lon) : "-") )

--- a/js/map.js
+++ b/js/map.js
@@ -246,6 +246,17 @@ function buildCircle(latlng,trackcolor,size,opacity,title)
     return circleMark;
 }
 
+function buildCircleEndRace(latlng, trackcolor, size)
+{
+    var circleMark = L.circle(latlng, {
+        color: trackcolor,
+        weight: 2,
+        fill: false,
+        radius: size,
+    });
+    return circleMark;
+}
+
 function buildTrace (tpath, color,weight,opacity,dashArray,dashOffset) {
 
     var trackLine = L.geodesic(tpath,
@@ -511,7 +522,7 @@ async function initialize(race,raceFleetMap)
             race.lMap.refPoints.push(latlng);
             
 
-            buildCircle(latlng,'red',race.legdata.end.radius * 1852.0,0).addTo(race.lMap.refLayer);
+            buildCircleEndRace(latlng, 'red', race.legdata.end.radius * 1852.0).addTo(race.lMap.refLayer);
 
                 
                 

--- a/js/util.js
+++ b/js/util.js
@@ -170,7 +170,7 @@ function genth(id, content, title, sortfield, sortmark) {
         if (sortfield && sortmark != undefined) {
             content = content + " " + (sortmark ? "&#x25b2;" : "&#x25bc;");
         }
-        var cspan;
+        var cspan = '';
         if (id=="th_twa" || id=="th_sail") {
             cspan = "colspan = 2";
         }


### PR DESCRIPTION
- Fix "undefined" display with <th> HTML elements generated for column titles in the Fleet tab.
- Fix of the data display on the mouseover of the icons of the "State" column of the "Fleet" tab.
- Fix of the display of the circle representing the finish line of the race.