### PR TITLE
Added border to player data line and help messages + Formatting the routing markers data

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -415,3 +415,7 @@ td.position>p {
 #colName {
     text-align:left;
 }
+
+.cursorHelp {
+    cursor: help !important;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -366,6 +366,10 @@ td.time, td.foil, td.position, td.type, td.name, td.agrd, td.man, td.options, td
     
 }
 
+td.options, td.state {
+    cursor: help;
+}
+
 td.gender, td.flag, td.userid, td.level, td.role, td.type, td.members {
     text-align: center;
     padding-left: 10px;
@@ -1074,4 +1078,8 @@ tr.us_line3>td>label, tr.us_line3t>td>label, tr.us_line3b>td>label {
 
 tr.highlightMe {
     border: 0.16em solid #b86dff;    
+}
+
+.cursorHelp {
+    cursor: help;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1071,3 +1071,7 @@ tr.us_line3>td>label, tr.us_line3t>td>label, tr.us_line3b>td>label {
 
     background-color: var(--bg_body_color);
 }
+
+tr.highlightMe {
+    border: 0.16em solid #b86dff;    
+}

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -419,10 +419,12 @@ var controller = function () {
                 res.xfactorStyle = 'style="color:orange ;"';
         }
 
+        res.nameClass = "";
 
         if (uid == currentUserId) {
             res.nameStyle = "color: #b86dff; font-weight: bold; ";
             res.bcolor = '#b86dff';
+            res.nameClass = ' highlightMe';
             if (!uinfo.displayName) {
                 res.name = 'Me';
             }        
@@ -1339,7 +1341,7 @@ var controller = function () {
                     } else
                         routerCell = '<td class="tdc"><span id="vrz:' + uid + '">&#x262F;</span></td>';
 
-                    return '<tr class="hovred" id="ui:' + uid + '">'
+                    return '<tr class="hovred' + bi.nameClass + '" id="ui:' + uid + '">'
                         + routerCell
                         + '<td class="time">' + formatTime(r.lastCalcDate) + '</td>'
                         + '<td class="Skipper" style="' + bi.nameStyle + '">' + bull + " " + bi.name + '</td>' 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -3691,6 +3691,7 @@ async function initializeMap(race) {
         await getOption("fleet_team",true);
         await getOption("fleet_rank",true);
         await getOption("fleet_racetime",true);
+        await getOption("fleet_speed", true);
         await getOption("fleet_dtu" ,true);
         await getOption("fleet_dtf" ,true);
         await getOption("fleet_twd" ,true);
@@ -3765,6 +3766,8 @@ async function initializeMap(race) {
         document.getElementById("abbreviatedOption").addEventListener("change", saveOption);
         document.getElementById("fleet_team").addEventListener("change", saveOption);
         document.getElementById("fleet_rank").addEventListener("change", saveOption);
+        document.getElementById("fleet_racetime").addEventListener("change", saveOption);
+        document.getElementById("fleet_speed").addEventListener("change", saveOption);
         document.getElementById("fleet_dtu" ).addEventListener("change", saveOption);
         document.getElementById("fleet_dtf" ).addEventListener("change", saveOption);
         document.getElementById("fleet_twd" ).addEventListener("change", saveOption);

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -313,7 +313,7 @@ var controller = function () {
             (r.curr.tsEndOfAutoSail &&(r.curr.tsEndOfAutoSail - r.curr.lastCalcDate) > 0);
         var autoSailTime = r.curr.hasPermanentAutoSails ? '∞' : Util.formatHMS(r.curr.tsEndOfAutoSail - r.curr.lastCalcDate);
         if (isAutoSail) {
-            sailInfo = sailInfo + " (A " + autoSailTime + ")";
+            sailInfo = sailInfo + " <span title='Auto Sails' class='cursorHelp'>&#x24B6;</span> " + autoSailTime;
         } else {
             sailInfo = sailInfo + " (Man)";
         }
@@ -391,7 +391,7 @@ var controller = function () {
             twaStyle: 'style="color: ' + ((uinfo.twa < 0) ? "red" : "green") + ';"',
             sail: sailNames[uinfo.sail] || "-",
             sSail : sailNames[uinfo.sail%10],
-            aSail : (uinfo.sail>10?"&#x24B6;":""),
+            aSail : (uinfo.sail > 10 ? "<span title='Auto Sails' class='cursorHelp'>&#x24B6;</span>" : ""),
             xfactorStyle: 'style="color:' + ((uinfo.xplained) ? ((drawTheme =='dark')?"#a5A5A5" :"black") : "red") + ';"',
             nameStyle: uinfo.nameStyle,
             bcolor: uinfo.bcolor,
@@ -1271,10 +1271,10 @@ var controller = function () {
                 }
                 if (r.isRegulated == true) {
                     // var lock = "&#128272;";
-                    var lock = "<b>&#x24B6;</b>";
+                    var lock = "<b title='TWA Locked' class='cursorHelp'>&#x24B6;</b>";
                 }
                 if (r.isRegulated == false) {
-                    var lock = "&#x25EF;";
+                    var lock = "<span title='TWA Unlocked' class='cursorHelp'>&#x25EF;</span>";
                 }
                 
                 var teamName = DM.teamModel.teamName;
@@ -1353,13 +1353,13 @@ var controller = function () {
                         + Util.gentd("TWD","",null, Util.roundTo(r.twd, 2+nbdigits) )
                         + Util.gentd("TWS","",null, Util.roundTo(bi.tws, 2+nbdigits) )
                         + Util.gentd("TWA", bi.twaStyle,null, Util.roundTo(bi.twa, 2+nbdigits) )
-                        + Util.gentd("TWA", 'style="color: grey; align:center;"',null, lock )
+                        + Util.gentd("TWA", 'style="color:grey; align:center; text-align:center;"', null, lock)
                         + Util.gentd("HDG", 'style="color:' + hdgFG + '";"' + hdgBold ,null, Util.roundTo(bi.heading, 2+nbdigits) )
                         + Util.gentd("Speed","",null, Util.roundTo(bi.speed, 2+nbdigits) )
                         + Util.gentd("VMG","",null, Util.roundTo(r.vmg, 2+nbdigits))
 //                        + Util.gentd("Sail","",null, '<span ' + bi.sailStyle + '>&#x25e2&#x25e3  </span>' + bi.sail )
                         + Util.gentd("Sail","",null, '<span ' + bi.sailStyle + '>&#x25e2&#x25e3  </span>' + bi.sSail )
-                        + Util.gentd("Sail","",null,  bi.aSail )
+                        + Util.gentd("Sail", 'style="text-align:center;"', null, bi.aSail)
                         + Util.gentd("Factor", bi.xfactorStyle,null, xfactorTxt )
                         + Util.gentd("Foils", "", null, (r.xoption_foils || "?"))
                         + Util.gentd("Stamina",bi.staminaStyle,null,staminaTxt)  

--- a/js/routingviewer.js
+++ b/js/routingviewer.js
@@ -211,12 +211,12 @@ function importGPXRoute(race,gpxFile,routerName,skipperName,color) {
         routeData.lat = lat;
         routeData.lon =  lon;
         routeData.timestamp = Date.parse(pt.time);
-        routeData.heading = "-";
-        routeData.tws = "-";
-        routeData.twa = "-";
-        routeData.twd = "-";
-        routeData.sail = "-";
-        routeData.speed = "-";
+        routeData.heading = "";
+        routeData.tws = "";
+        routeData.twa = "";
+        routeData.twd = "";
+        routeData.sail = "";
+        routeData.speed = "";
         addNewPoints(race.id,routeName.cleanSpecial(),routeData);
 
     });
@@ -257,8 +257,8 @@ function importExternalRouter(race,fileTxt,routerName,skipperName,color,mode) {
             lat = Number(poi[3]);
             lon = Number(poi[4]);
             hdg = poi[5]+ "°";
-            tws = Util.roundTo(poi[11], 1+nbdigits)+ "kts";
-            stw = Util.roundTo(poi[9], 1+nbdigits) + "kts";
+            tws = Util.roundTo(poi[11], 1+nbdigits)+ " kts";
+            stw = Util.roundTo(poi[9], 1+nbdigits) + " kts";
     
             splitDate = poi[0].split(" ");
             heure = splitDate[1];
@@ -288,8 +288,8 @@ function importExternalRouter(race,fileTxt,routerName,skipperName,color,mode) {
             lat = Number(poi[1]);
             lon = Number(poi[2]);
             hdg = poi[3]+ "°";
-            tws = Util.roundTo(poi[8], 1+nbdigits)+ "kts";
-            stw = Util.roundTo(poi[4], 1+nbdigits) + "kts";
+            tws = Util.roundTo(poi[8], 1+nbdigits)+ " kts";
+            stw = Util.roundTo(poi[4], 1+nbdigits) + " kts";
     
             
             splitDate = poi[0].split(" ");
@@ -303,7 +303,7 @@ function importExternalRouter(race,fileTxt,routerName,skipperName,color,mode) {
             if(poi[6]>180) poi[6] -=360;
             twa = Util.roundTo(poi[6], 1+nbdigits)+ "°";
             twd = Util.roundTo(poi[7], 1+nbdigits) + "°";
-            sail = "---"; //todo foud link between avalon number and sail    
+            sail = "(" + poi[5] + ")"; //todo found link between avalon number and sail (temporarily, display the id)
         }
         
         
@@ -767,11 +767,22 @@ function buildMarkerTitle(point)
 
     var ttw = point.timestamp-currentTs;
 
-    var title = "Position : " + position + "\n" +
-        "Date : " + newDate + " (" + Util.formatDHMS(ttw) + ")\n" +
-        "TWA : " + point.twa.replace(/&deg;/g, "°") + "  |  HDG : " + point.heading.replace(/&deg;/g, "°") + "\n" +
-        "TWD : " + point.twd.replace(/&deg;/g, "°") + "  |  TWS : " + point.tws + "\n" +
-        "Sail : " + point.sail + "  |  Speed : " + point.speed ;
+    var textTWA = point.twa ? "TWA: <b>" + point.twa.replace(/&deg;/g, "°") + "</b>" : "";
+    var textHDG = point.heading ? "HDG: <b>" + point.heading.replace(/&deg;/g, "°") + "</b><br>" : "";
+    var textTWD = point.twd ? "TWD: " + point.twd.replace(/&deg;/g, "°") : "";
+    var textTWS = point.tws ? "TWS: " + point.tws + "<br>" : "";
+    var textSail = point.sail ? "Sail: " + point.sail : "";
+    var textSpeed = point.speed ? "Speed: " + point.speed : "";
+    // Data visual separator
+    textTWA += point.twa && point.heading ? "&nbsp;|&nbsp;" : "";
+    textTWD += point.twd && point.tws ? "&nbsp;|&nbsp;" : "";
+    textSail += point.sail && point.speed ? "&nbsp;|&nbsp;" : "";
+
+    var title = "<b>" + newDate + "</b> (" + Util.formatDHMS(ttw) + ")<br>"
+        + position + "<br>"
+        + textTWA + textHDG
+        + textTWD + textTWS
+        + textSail + textSpeed;
 
     return title;
 

--- a/js/zezoscript.js
+++ b/js/zezoscript.js
@@ -158,10 +158,10 @@ function zezoCall(uinfo,raceInfos,color,race) {
                     routeData.lat = getLatitude(top, scale[1]);
                     routeData.lon =  getLongitude(left, scale[1]);;
                     routeData.timestamp = Date.parse(isoDate);
-                    routeData.heading = btw;
-                    routeData.tws = tws;
-                    routeData.twa = twa;
-                    routeData.twd = twd;
+                    routeData.heading = btw + "°";
+                    routeData.tws = tws + "s";
+                    routeData.twa = twa + "°";
+                    routeData.twd = twd + "°";
                     routeData.sail = sail;
                     routeData.speed = stw;
                     rt.addNewPoints(raceInfos.id,routeNameClean,routeData);


### PR DESCRIPTION
- Added a colored border around the player's data line in the Fleet tab for easier viewing.
- Added smooth formatting for data displayed when hovering over a marker of an imported routing.
- Added "help" cursor when hovering over  the data of the column "Options" & "State" of the Fleet tab.
- Added descriptive text and "help" cursor on the special character "Ⓐ" displayed for sails and TWA padlock data.
- Fixed the "A" character to "Ⓐ" for sails data.
- Fixed saving of "fleet_racetime" and "fleet_speed" configuration options when changing choices in the "Config" tab.