### PR TITLE
Added option to hide "Command/Actions" lines + darker coloring layer map + HTML/Spelling tweaks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -503,8 +503,13 @@ fieldset {
 
 
 #userConfig {
-    padding-left: 1em;
+    padding: 0 1em;
 }
+
+#userConfig button {
+    padding: 3px 12px;
+}
+
 .us_general {
     border-spacing: 0 25px;
     border-collapse: separate;
@@ -550,7 +555,7 @@ tr.us_line2>td {
 tr.us_line>td.us_title, tr.us_line2>td.us_title , tr.us_line3>td.us_title, tr.us_line3t>td.us_title, tr.us_line3b>td.us_title{
     font-size: 1.2em;
 }
-tr.us_line>td>label, tr.us_line2>td>label, tr.us_line3>td>label, tr.us_line3t>td>label, tr.us_line3b>td>label #bt_exportPolar {
+tr.us_line>td>label, tr.us_line2>td>label, tr.us_line3>td>label, tr.us_line3t>td>label, tr.us_line3b>td>label {
     font-size: 1em;
 }
 
@@ -1111,6 +1116,5 @@ tr.highlightMe {
 }
 
 #sel_Seperator {
-    font-size: 1.1em;
-    margin-bottom: 1em;
+    font-size: 14px;
 }

--- a/dashboard.html
+++ b/dashboard.html
@@ -373,6 +373,10 @@
                             <td colspan="13"></td>
                         </tr>
                         <tr class="us_line">
+                            <td class="us_title" id="t_config_l">Journal</td>
+                            <td colspan="21"><input type="checkbox" id="hideCommandsLines"><label id="t_hideCommandsLines">Cacher les lignes correspondantes aux actions/commandes</label></td>
+                        </tr>
+                        <tr class="us_line">
                             <td class="us_title" id="t_config_m">Carte</td>
                             <td colspan="4"><input type="checkbox" id="track_infos"><label id="t_track_infos">charger infos traces  (redémarrage dashboard requis)</label></td>
                             <td colspan="17"></td>                        

--- a/dashboard.html
+++ b/dashboard.html
@@ -19,6 +19,7 @@
         <script src="./lib/polylineDecorator/leaflet.polylineDecorator.js"></script>
         <script src="./lib/rotatedMarkers/leaflet.rotatedMarker.js"></script>
         <script src="./lib/geodesicLine/leaflet.geodesic.umd.min.js"></script>
+        <script src="./lib/tileLayerColorFilter/leaflet.tilelayer-colorfilter.min.js"></script>
         <script src="./lib/gpxParser/GPXParser.min.js"></script>
         <script src="./lib/md5/md5.min.js"></script>
         <script src="./js/stamina.js"></script>

--- a/dashboard.html
+++ b/dashboard.html
@@ -370,7 +370,7 @@
                             <td class="us_title" id="t_config_rs">Race Status</td>
                             <td colspan="4"><input type="checkbox" id="showBVMGSpeed"><label id="t_showBVMGSpeed">Afficher Vitesse du bateau à la VMG</label></td>
                             <td colspan="4"><input type="checkbox" id="with_LastCommand" ><label id="t_with_LastCommand">Afficher derniers ordres</label></td>
-                            <td colspan="12"></td>
+                            <td colspan="13"></td>
                         </tr>
                         <tr class="us_line">
                             <td class="us_title" id="t_config_m">Carte</td>
@@ -405,21 +405,25 @@
                             <td><input type="checkbox" id="fleet_position"  checked><label id="t_fleet_position">Position</label></td>           
                             <td><input type="checkbox" id="fleet_options"  checked><label id="t_fleet_options">Options</label></td>     
                             <td><input type="checkbox" id="fleet_state"  checked><label id="t_fleet_state">State</label></td>  
+                            <td colspan="3"></td>
+                        </tr>
+                        <tr class="us_line2">
+                            <td class="us_title">Export</td>
+                            <td width="150px">
+                                <select id="sel_Seperator" name="type" class="notif">
+                                    <option value ="sep_1" id="t_sep_1">; (EU style)</option>
+                                    <option value ="sep_2" id="t_sep_2">, (US style)</option>
+                                    <option value ="sep_3" id="t_sep_3">Tab (<a href="https://sailranks.com/v/home">SailRank</a>)</option>
+                                </select>
+                            </td>
+                            <td colspan="20">
+                                <button id="bt_exportPolar">Export polars</button>
+                                <button id="bt_exportStamina">Export stamina</button>
+                                <button id="bt_exportFleet">Export FleetInfos</button>
+                            </td>
                         </tr>
                     </tbody>
                 </table>
-            </div>
-            <div>            
-                <select id="sel_Seperator" name="type" class="notif">
-                    <option value ="sep_1" id="t_sep_1">; (EU style)</option>
-                    <option value ="sep_2" id="t_sep_2">, (US style)</option>
-                    <option value ="sep_3" id="t_sep_3">Tab (<a href="https://sailranks.com/v/home">SailRank</a>)</option>
-                </select>
-            </div>
-            <div>
-                <button id="bt_exportPolar">Export polars</button>
-                <button id="bt_exportStamina">Export stamina</button>
-                <button id="bt_exportFleet">Export FleetInfos</button>
             </div>
         </div>
     </div>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1401,12 +1401,13 @@ var controller = function () {
 
         function makeRaceLineLogCmd(cinfo) {
             if(!cinfo.action) return"";
-            return '<tr>'
-           + '<td class="time">' + formatDateUTC(cinfo.ts) + '</td>'           // Modif
-           + '<td colspan="3">Command @ ' + formatDateUTC() + '</td>'                             // Modif
-           + '<td colspan="16">Actions:' + printLastCommand(cinfo.action) + '</td>'
-           + '</tr>';
-       }
+            return '<tr class="commandLine">'
+            + '<td class="time">' + formatDateUTC(cinfo.ts) + '</td>' // Modif
+            + '<td colspan="3">Command @ ' + formatDateUTC() + '</td>' // Modif
+            + '<td colspan="16">Actions:' + printLastCommand(cinfo.action) + '</td>'
+            + '</tr>';
+        }
+
         function makeRaceLineLog(rinfo)
         {
             function isDifferingSpeed(realSpeed, calculatedSpeed) {
@@ -1580,6 +1581,21 @@ var controller = function () {
             + '</table>';
     }
 
+    function makeTableHTMLProcess(r) {
+        divRecordLog.innerHTML = makeTableHTML(r);
+        updateToggleRaceLogCommandsLines();
+    }
+
+    function updateToggleRaceLogCommandsLines() {
+        var commandLines = document.querySelectorAll('tr.commandLine');
+        commandLines.forEach(function(line) {
+            if (document.getElementById("hideCommandsLines").checked) {
+                line.style.display = 'none';
+            } else {
+                line.style.display = '';
+            }
+        });
+    }
 
     function clearRecordedData(rid) {
         var race = races.get(rid);
@@ -2396,7 +2412,7 @@ var controller = function () {
         await DM.saveRaceLogInfos(r.id);
 
         if (r.id == selRace.value) {
-            divRecordLog.innerHTML = makeTableHTML(r);  
+            makeTableHTMLProcess(r);
         }
         // updateMapWaypoints(r);
     }
@@ -2474,7 +2490,7 @@ var controller = function () {
             await DM.addRaceLogInfosLine(r.id,rliLine);
             await DM.saveRaceLogInfos(r.id);
             if (r.id == selRace.value) {
-                divRecordLog.innerHTML = makeTableHTML(r);
+                makeTableHTMLProcess(r);
             }
         }
     }
@@ -2513,7 +2529,7 @@ var controller = function () {
         currentRaceId = raceId;
         makeRaceStatusHTML();
         //await DM.initRaceLogInfos(raceId);
-        divRecordLog.innerHTML = makeTableHTML(race);
+        makeTableHTMLProcess(race);
         if(race && race.recordedData) {
             gr.upDateGraph(race.recordedData);
         }
@@ -3650,6 +3666,7 @@ async function initializeMap(race) {
         await getOption("with_LastCommand",false);
         await getOption("vrzenPositionFormat",false);
         await getOption("showBVMGSpeed",false);
+        await getOption("hideCommandsLines", false);
         await getOption("abbreviatedOption",true);
         await getOption("fleet_team",true);
         await getOption("fleet_rank",true);
@@ -3748,6 +3765,8 @@ async function initializeMap(race) {
         document.getElementById("with_LastCommand").addEventListener("change", makeRaceStatusHTML);
         document.getElementById("vrzenPositionFormat").addEventListener("change", saveOption);
         document.getElementById("showBVMGSpeed").addEventListener("change", saveOption);
+        document.getElementById("hideCommandsLines").addEventListener("change", saveOption);
+        document.getElementById("hideCommandsLines").addEventListener("change", updateToggleRaceLogCommandsLines);
         document.getElementById("abbreviatedOption").addEventListener("change", saveOption);
         document.getElementById("fleet_team").addEventListener("change", saveOption);
         document.getElementById("fleet_rank").addEventListener("change", saveOption);
@@ -3839,7 +3858,7 @@ async function initializeMap(race) {
         divRaceStatus = document.getElementById("raceStatus");
         divFriendList = document.getElementById("friendList");
         divRecordLog = document.getElementById("recordlog");
-        divRecordLog.innerHTML = makeTableHTML();
+        makeTableHTMLProcess();
         cbRawLog = document.getElementById("cb_rawlog");
         divRawLog = document.getElementById("rawlog");
         cb2digits = document.getElementById("2digits");
@@ -3947,7 +3966,7 @@ async function initializeMap(race) {
                 race.lMap = undefined;
             });
             makeRaceStatusHTML();
-            divRecordLog.innerHTML = makeTableHTML();
+            makeTableHTMLProcess();
             updateFleetHTML();
             buildlogBookHTML();
         };
@@ -4240,7 +4259,7 @@ async function initializeMap(race) {
             gr.upDateGraph(race.recordedData);
         }
 
-        divRecordLog.innerHTML = makeTableHTML(race);
+        makeTableHTMLProcess(race);
         updateFleetHTML(raceFleetMap.get(selRace.value));
         lMap.updateMapFleet(race,raceFleetMap);
         rt.updateFleet(race,raceFleetMap);
@@ -4865,6 +4884,9 @@ async function initializeMap(race) {
             document.getElementById("t_config_rs").innerHTML = "Race Status";
             document.getElementById("t_showBVMGSpeed").innerHTML = "Afficher Vitesse du bateau à la VMG";
             document.getElementById("t_with_LastCommand").innerHTML = "Afficher derniers ordres";
+
+            document.getElementById("t_config_l").innerHTML = "Journal";
+            document.getElementById("t_hideCommandsLines").innerHTML = "Cacher les lignes correspondantes aux actions/commandes";
             
             document.getElementById("t_config_m").innerHTML = "Carte";
             document.getElementById("t_track_infos").innerHTML = "Charger infos traces (redémarrage dashboard requis)"		;
@@ -4957,6 +4979,9 @@ async function initializeMap(race) {
             document.getElementById("t_config_rs").innerHTML = "Race Status";
             document.getElementById("t_showBVMGSpeed").innerHTML = "Show boat speed at VMG";
             document.getElementById("t_with_LastCommand").innerHTML = "Show last commands";
+            
+            document.getElementById("t_config_l").innerHTML = "Race Log";
+            document.getElementById("t_hideCommandsLines").innerHTML = "Hide lines corresponding to actions/commands";
             
             document.getElementById("t_config_m").innerHTML = "Map";
             document.getElementById("t_track_infos").innerHTML = "Load track infos (dashboard restart needed)";

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -4799,8 +4799,8 @@ async function initializeMap(race) {
     function translateDash () {
 
         if(lang == "fr") {
-            document.getElementById("t_boat").innerHTML = "Bateau : ";	
-            document.getElementById("t_team").innerHTML = "Equipe: ";	
+            document.getElementById("t_boat").innerHTML = "Bateau: ";	
+            document.getElementById("t_team").innerHTML = "Équipe: ";	
             document.getElementById("t_race").innerHTML = "Course";	
             document.getElementById("t_NMEA").innerHTML = "Sortie NMEA";
             document.getElementById("t_help").innerHTML = "Aide";
@@ -4815,14 +4815,14 @@ async function initializeMap(race) {
             document.getElementById("t_rawLog").innerHTML = "Raw Log";
             
             document.getElementById("t_filter").innerHTML = "Filtres";
-            document.getElementById("lbl_team").innerHTML = '<span style="color:Red;">&#x2B24;</span>&nbsp;Equipe';
+            document.getElementById("lbl_team").innerHTML = '<span style="color:Red;">&#x2B24;</span>&nbsp;Équipe';
             document.getElementById("lbl_friends").innerHTML = '<span style="color:LimeGreen;">&#x2B24;</span>&nbsp;Amis';
             document.getElementById("lbl_top").innerHTML = '<span style="color:GoldenRod;">&#x2B24;</span>&nbsp;Top VSR';
             document.getElementById("lbl_sponsors").innerHTML = '<span style="color:DarkSlateBlue;">&#x2B24;</span>&nbsp;Sponsors';
-            document.getElementById("lbl_certified").innerHTML = '<span style="color:DodgerBlue;">&#x2B24;</span>&nbsp;Certifié';
+            document.getElementById("lbl_certified").innerHTML = '<span style="color:DodgerBlue;">&#x2B24;</span>&nbsp;Certifiés';
             document.getElementById("lbl_opponents").innerHTML = '<span style="color:lightgray;">&#x2B24;</span>&nbsp;Adversaires';
             document.getElementById("lbl_reals").innerHTML = '<span style="color:Chocolate;">&#x2B24;</span>&nbsp;Réels';
-            document.getElementById("lbl_selected").innerHTML = '<span style="color:HotPink;">&#x2B24;</span>&nbsp;Sélectionné';
+            document.getElementById("lbl_selected").innerHTML = '<span style="color:HotPink;">&#x2B24;</span>&nbsp;Sélectionnés';
             document.getElementById("lbl_inrace").innerHTML = 'En course';
             
             document.getElementById("lbl_helpLmap").innerHTML = "Aide";
@@ -4835,7 +4835,7 @@ async function initializeMap(race) {
             document.getElementById("bt_rt_addLmap").innerHTML = "Import";
             
             document.getElementById("bt_cleanGraph").innerHTML = "Effacer graphiques";
-            document.getElementById("bt_exportGraphData").innerHTML = "Export data";
+            document.getElementById("bt_exportGraphData").innerHTML = "Exporter les données";
             
             document.getElementById("t_notif2").innerHTML = "Notifications et rappels";
             document.getElementById("t_notif21").innerHTML = 'Sélectionner une course : <select id="sel_raceNotif" name="raceNotif" class="notif"><option>---</option></select>';
@@ -4855,11 +4855,11 @@ async function initializeMap(race) {
             
             
             
-            document.getElementById("t_config_g").innerHTML = "General";
+            document.getElementById("t_config_g").innerHTML = "Général";
             document.getElementById("t_vrzenPositionFormat").innerHTML = 'Afficher position sans le séparateur "-" (redémarrage dashboard requis)';
             document.getElementById("t_2digits").innerHTML = "+1 digit";
-            document.getElementById("t_reuse_tab").innerHTML = "Re-utilisation onglet";
-            document.getElementById("t_local_time").innerHTML = "Local times";
+            document.getElementById("t_reuse_tab").innerHTML = "Réutilisation onglet";
+            document.getElementById("t_local_time").innerHTML = "Heure locale";
             document.getElementById("t_ITYC_record").innerHTML = "Envoi infos ITYC";
             
             document.getElementById("t_config_rs").innerHTML = "Race Status";
@@ -4867,7 +4867,7 @@ async function initializeMap(race) {
             document.getElementById("t_with_LastCommand").innerHTML = "Afficher derniers ordres";
             
             document.getElementById("t_config_m").innerHTML = "Carte";
-            document.getElementById("t_track_infos").innerHTML = "charger infos traces  (redémarrage dashboard requis)"		;
+            document.getElementById("t_track_infos").innerHTML = "Charger infos traces (redémarrage dashboard requis)"		;
                 
             document.getElementById("t_config_f").innerHTML = "Flotte";
             document.getElementById("t_abbreviatedOption").innerHTML = "Options abrégées";
@@ -4884,14 +4884,14 @@ async function initializeMap(race) {
             document.getElementById("t_fleet_options").innerHTML = "Options";
             document.getElementById("t_fleet_state").innerHTML = "State";
             
-            document.getElementById("bt_exportPolar").innerHTML = "Export polars";
-            document.getElementById("bt_exportStamina").innerHTML = "Export stamina";
-            document.getElementById("bt_exportFleet").innerHTML = "Export FleetInfos";
+            document.getElementById("bt_exportPolar").innerHTML = "Exporter Polaires";
+            document.getElementById("bt_exportStamina").innerHTML = "Exporter Stamina";
+            document.getElementById("bt_exportFleet").innerHTML = "Exporter FleetInfos";
             
             document.getElementById("t_credit_all").innerHTML = "Tous les contributeurs inconnus !";
             document.getElementById("t_credit_me").innerHTML = "Votre serviteur !";
         } else {
-            document.getElementById("t_boat").innerHTML = "Boat : ";	
+            document.getElementById("t_boat").innerHTML = "Boat: ";	
             document.getElementById("t_team").innerHTML = "Team: ";	
             document.getElementById("t_race").innerHTML = "Race";	
             document.getElementById("t_NMEA").innerHTML = "NMEA output";
@@ -4917,7 +4917,7 @@ async function initializeMap(race) {
             document.getElementById("lbl_selected").innerHTML = '<span style="color:HotPink;">&#x2B24;</span>&nbsp;Selected';
             document.getElementById("lbl_inrace").innerHTML = 'Racing';
             
-            document.getElementById("lbl_helpLmap").innerHTML = "Helps";
+            document.getElementById("lbl_helpLmap").innerHTML = "Help";
             document.getElementById("lbl_showMarkersLmap").innerHTML = "Marks";
             document.getElementById("lbl_showTracksLmap").innerHTML = "Tracks";
             document.getElementById("lbl_rt_openLmap").innerHTML = "Add";	
@@ -4930,8 +4930,8 @@ async function initializeMap(race) {
             document.getElementById("bt_exportGraphData").innerHTML = "Export data";
             
             document.getElementById("t_notif2").innerHTML = "Notifications and recall";
-            document.getElementById("t_notif21").innerHTML = 'Select a race : <select id="sel_raceNotif" name="raceNotif" class="notif"><option>---</option></select>';
-            document.getElementById("t_notif22").innerHTML = "Paramètres :";
+            document.getElementById("t_notif21").innerHTML = 'Select a race: <select id="sel_raceNotif" name="raceNotif" class="notif"><option>---</option></select>';
+            document.getElementById("t_notif22").innerHTML = "Parameters:";
             
             document.getElementById("t_notif_opt1").innerHTML = "inferior";
             document.getElementById("t_notif_opt2").innerHTML = "inferior or equal";
@@ -4950,8 +4950,8 @@ async function initializeMap(race) {
             document.getElementById("t_config_g").innerHTML = "General";
             document.getElementById("t_vrzenPositionFormat").innerHTML = 'Show position without the separator "-" (dashboard restart needed)';
             document.getElementById("t_2digits").innerHTML = "+1 digit";
-            document.getElementById("t_reuse_tab").innerHTML = "tab re-use";
-            document.getElementById("t_local_time").innerHTML = "Local times";
+            document.getElementById("t_reuse_tab").innerHTML = "Tab re-use";
+            document.getElementById("t_local_time").innerHTML = "Local time";
             document.getElementById("t_ITYC_record").innerHTML = "Send infos ITYC";
             
             document.getElementById("t_config_rs").innerHTML = "Race Status";
@@ -4959,11 +4959,11 @@ async function initializeMap(race) {
             document.getElementById("t_with_LastCommand").innerHTML = "Show last commands";
             
             document.getElementById("t_config_m").innerHTML = "Map";
-            document.getElementById("t_track_infos").innerHTML = "Load track infos  (dashboard restart needed)"		;
+            document.getElementById("t_track_infos").innerHTML = "Load track infos (dashboard restart needed)";
                 
             document.getElementById("t_config_f").innerHTML = "Fleet";
-            document.getElementById("t_abbreviatedOption").innerHTML = "shorted options";
-            document.getElementById("t_auto_clean").innerHTML = "old data cleaner";
+            document.getElementById("t_abbreviatedOption").innerHTML = "Shorted options";
+            document.getElementById("t_auto_clean").innerHTML = "Old data cleaner";
             
             document.getElementById("t_config_c").innerHTML = "Columns";
             document.getElementById("t_fleet_team").innerHTML = "Team";
@@ -4976,8 +4976,8 @@ async function initializeMap(race) {
             document.getElementById("t_fleet_options").innerHTML = "Options";
             document.getElementById("t_fleet_state").innerHTML = "State";
             
-            document.getElementById("bt_exportPolar").innerHTML = "Export polars";
-            document.getElementById("bt_exportStamina").innerHTML = "Export stamina";
+            document.getElementById("bt_exportPolar").innerHTML = "Export Polars";
+            document.getElementById("bt_exportStamina").innerHTML = "Export Stamina";
             document.getElementById("bt_exportFleet").innerHTML = "Export FleetInfos";
             
             document.getElementById("t_credit_all").innerHTML = "All unknows contributors !";

--- a/js/map.js
+++ b/js/map.js
@@ -547,6 +547,12 @@ async function initialize(race,raceFleetMap)
 
             document.getElementById("tab-content3").appendChild(divMap);
 
+            let mapTileColorFilterDarkMode = [
+                'hue:195deg',
+                'invert:92%',
+                'saturate:112%',
+            ];
+
             var Esri_WorldImagery = L.tileLayer('http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
                 minZoom: 2, maxZoom: 40, maxNativeZoom: 40, attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, ' +
                     'AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
@@ -555,9 +561,15 @@ async function initialize(race,raceFleetMap)
             var OSM_Layer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 minZoom: 2, maxZoom: 40, maxNativeZoom: 40, attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
             });
+
+            var OSM_DarkLayer = L.tileLayer.colorFilter('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                minZoom: 2, maxZoom: 40, maxNativeZoom: 40, attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+                filter: mapTileColorFilterDarkMode                
+            });
         
             var baseLayers = {
                 "Carte": OSM_Layer,
+                "Custom": OSM_DarkLayer,
                 "Satellite": Esri_WorldImagery
             };
         

--- a/js/map.js
+++ b/js/map.js
@@ -954,7 +954,7 @@ function updateMapMe(race, track) {
                     var deltaD =  Util.gcDistance(track[i-1], segment);
                     var speed = Util.roundTo(Math.abs(deltaD / deltaT * 3600), 2);
                     var timeStamp = Util.formatShortDate(segment.ts,undefined,(displayFilter & 0x800));
-                    var title =  "Me " + " : " + timeStamp + " | " + speed + "kn" + " | " + (segment.tag || "-");
+                    var title =  "Me " + "<br><b>" + timeStamp + "</b><br>Speed: " + speed + " kts" + (segment.tag ? "<br>" + segment.tag : "");
                     var trackcolor = "#b86dff";
                     buildCircle(pos, race.lMap.meLayerMarkers,trackcolor, 1.5 ,1, title);
                     race.lMap.refPoints.push(pos[1]);
@@ -980,10 +980,9 @@ function updateMapMe(race, track) {
 
         if(race.lMap.meBoatLayer) map.removeLayer(race.lMap.meBoatLayer);
         race.lMap.meBoatLayer  = L.layerGroup();
-        var title = "Me | HDG : " 
-                    + Util.roundTo(race.curr.heading, 2 + nbdigits) 
-                    + " | TWA : " + Util.roundTo(race.curr.twa, 2 + nbdigits) 
-                    + " | SPD : " + Util.roundTo(race.curr.speed, 2+nbdigits);
+        var title = "Me (Last position)<br>TWA: <b>" + Util.roundTo(race.curr.twa, 2 + nbdigits) + "°</b>"
+                    + " | HDG: <b>" + Util.roundTo(race.curr.heading, 2 + nbdigits) + "°</b>"
+                    + "<br>Speed: " + Util.roundTo(race.curr.speed, 2 + nbdigits) + " kts";
 
         buildMarker(pos, race.lMap.meBoatLayer, buildBoatIcon("#b86dff","#000000",0.4), title,  200, 0.5,race.curr.heading);
      }
@@ -1157,7 +1156,7 @@ function updateMapFleet(race,raceFleetMap) {
             }
             
             var nbdigits = (document.getElementById("2digits").checked?1:0);
-            var info = bi.name + " | HDG : " + Util.roundTo(bi.heading, 1+nbdigits) + " | TWA : " + Util.roundTo(bi.twa, 2+nbdigits) + " | SPD : " + Util.roundTo(bi.speed, 2 + nbdigits);
+            var info = bi.name + "<br>TWA: <b>" + Util.roundTo(bi.twa, 2+nbdigits) + "°</b> | HDG: <b>" + Util.roundTo(bi.heading, 1+nbdigits) + "°</b><br>Sail: " + bi.sail + " | Speed: " + Util.roundTo(bi.speed, 2 + nbdigits) + " kts";
             if (elem.startDate && race.type == "record") {
                 info += " | Elapsed : " + Util.formatDHMS(elem.ts - elem.startDate);
             }
@@ -1181,7 +1180,7 @@ function updateMapFleet(race,raceFleetMap) {
                                 var deltaD =  Util.gcDistance(elem.track[i-1], segment);
                                 var speed = Util.roundTo(Math.abs(deltaD / deltaT * 3600), 2);
                                 var timeStamp = Util.formatShortDate(segment.ts,undefined,(displayFilter & 0x800));
-                                var title =  elem.displayName + " : " + timeStamp + " | " + speed + "kn" + " | " + (segment.tag || "-");
+                                var title =  elem.displayName + "<br><b>" + timeStamp + "</b> | Speed: " + speed + " kts" + (segment.tag ? "<br>" + segment.tag : "");
 
                                 buildCircle(pos2,race.lMap.fleetLayerMarkers,bi.bcolor, 1.5,1,title);
                         }

--- a/lib/tileLayerColorFilter/leaflet.tilelayer-colorfilter.min.js
+++ b/lib/tileLayerColorFilter/leaflet.tilelayer-colorfilter.min.js
@@ -1,0 +1,7 @@
+/*
+  Leaflet.TileLayer.ColorFilter
+  (c) 2018, Claudio T. Kawakani
+  A simple and lightweight Leaflet plugin to apply CSS filters on map tiles.
+  https://github.com/xtk93x/Leaflet.TileLayer.ColorFilter
+*/
+"use strict";L.TileLayer.ColorFilter=L.TileLayer.extend({intialize:function(t,i){L.TileLayer.prototype.initialize.call(this,t,i)},colorFilter:function(){var r=["blur:px","brightness:%","bright:brightness:%","bri:brightness:%","contrast:%","con:contrast:%","grayscale:%","gray:grayscale:%","hue-rotate:deg","hue:hue-rotate:deg","hue-rotation:hue-rotate:deg","invert:%","inv:invert:%","opacity:%","op:opacity:%","saturate:%","saturation:saturate:%","sat:saturate:%","sepia:%","sep:sepia:%"];return(this.options.filter?this.options.filter:[]).map(function(t){var i=t.toLowerCase().split(":");if(2===i.length){var e=r.find(function(t){return t.split(":")[0]===i[0]});if(e)return e=e.split(":"),i[1]+=/^\d+$/.test(i[1])?e[e.length-1]:"","".concat(e[e.length-2],"(").concat(i[1],")")}return""}).join(" ")},_initContainer:function(){L.TileLayer.prototype._initContainer.call(this);this._container.style.filter=this.colorFilter()},updateFilter:function(t){this.options.filter=t,this._container&&(this._container.style.filter=this.colorFilter())}}),L.tileLayer.colorFilter=function(t,i){return new L.TileLayer.ColorFilter(t,i)};


### PR DESCRIPTION
- Added choice to select a darker coloring layer for the Leaflet map.
- Added functionality to hide the "Command/Actions" lines of the "Racelog" tab. Option can be activated from the "Config" tab.
- Added smooth formatting for data displayed when hovering over a marker of an imported routing or over a boat.
- Modification of the HTML display of the "Export" part of the "Config" tab to match the general structure defined.
- Some small spelling corrections in French and English.