### PR TITLE
Added display of sail changes on imported routings + wind resolution model data + tweaks & fixes

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -423,3 +423,8 @@ td.position>p {
 .cursorHelp {
     cursor: help !important;
 }
+
+td.position p {
+    font-size: 11px !important;
+    line-height: 16px !important;
+}

--- a/css/content.css
+++ b/css/content.css
@@ -78,6 +78,10 @@
     background-repeat: no-repeat;
     background-size: contain;
 }*/
+body {
+    background-color: var(--bg_body_color) !important;
+}
+
 #main-header, .et_pb_section {
     background-color: var(--bg_body_color)!important;
     color: var(--body_color)!important;

--- a/css/style.css
+++ b/css/style.css
@@ -216,6 +216,9 @@ tr.hov:hover {
 tr.hovred:hover {
     border: 0.16em solid red;    
 }
+.selectedLine {
+    border: 0.16em solid rgb(245, 245, 93);
+}
 
 tr {
     height: 23px;

--- a/css/style.css
+++ b/css/style.css
@@ -271,6 +271,38 @@ td.tdc {
     width: 25px;
     padding: 0px;
 }
+
+#th_rl_date {
+    width: 120px;
+}
+#th_rl_rank {
+    width: 70px;
+}
+#th_rl_deltaDistance, #th_rl_deltaTime {
+    width: 80px;
+}
+#th_rl_sail, #th_rl_gybe, #th_rl_tack {
+    width: 60px;
+}
+#th_rl_calcSpeed {
+    width: 110px;
+}
+#th_rl_reportedSpeed {
+    width: 80px;
+}
+#th_rl_dtf {
+    width: 120px;
+}
+#th_rl_factor {
+    width: 130px;
+}
+#th_rl_stamina {
+    width: 100px;
+}
+#th_lu {
+    width: 82px;
+}
+
 td.remove {
     padding: 0px;
     text-align: center;
@@ -308,6 +340,9 @@ td.twa {
 }
 
 
+td.stamina {
+    text-align: right;
+}
 
 td.speed1 {
     background-color: var(--td_speed1_color);

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1474,7 +1474,7 @@ var controller = function () {
         function makeRaceLineLogCmd(cinfo) {
             if(!cinfo.action) return"";
             return '<tr class="commandLine">'
-           + '<td class="time">' + formatDateUTC(cinfo.ts) + '</td>' 
+            + '<td class="time">' + formatDateUTC(cinfo.ts, 1) + '</td>'
            + '<td colspan="3">Command @ ' + formatDateUTC(cinfo.ts) + '</td>'
            + '<td colspan="16">Actions:' + printLastCommand(cinfo.action) + '</td>'
            + '</tr>';

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1668,8 +1668,10 @@ var controller = function () {
     function updateToggleRaceLogCommandsLines() {
         var commandLines = document.querySelectorAll('tr.commandLine');
         commandLines.forEach(function(line, index) {
-            if (document.getElementById("hideCommandsLines").checked && index !== 0) {
-                line.style.display = 'none';
+            if (document.getElementById("hideCommandsLines").checked) {
+                if ( index > 2) {
+                    line.style.display = 'none';
+                }
             } else {
                 line.style.display = '';
             }
@@ -5039,7 +5041,7 @@ async function initializeMap(race) {
             document.getElementById("t_with_LastCommand").innerHTML = "Afficher derniers ordres";
 
             document.getElementById("t_config_l").innerHTML = "Journal";
-            document.getElementById("t_hideCommandsLines").innerHTML = "Cacher les lignes correspondantes aux actions/commandes (sauf la dernière)";
+            document.getElementById("t_hideCommandsLines").innerHTML = "Cacher les lignes correspondantes aux actions/commandes (sauf les 3 dernières)";
             
             document.getElementById("t_config_m").innerHTML = "Carte";
             document.getElementById("t_track_infos").innerHTML = "Charger infos traces (redémarrage dashboard requis)"		;
@@ -5148,7 +5150,7 @@ async function initializeMap(race) {
             document.getElementById("t_with_LastCommand").innerHTML = "Show last commands";
             
             document.getElementById("t_config_l").innerHTML = "Race Log";
-            document.getElementById("t_hideCommandsLines").innerHTML = "Hide lines corresponding to actions/commands (except last one)";
+            document.getElementById("t_hideCommandsLines").innerHTML = "Hide lines corresponding to actions/commands (except the last 3)";
             
             document.getElementById("t_config_m").innerHTML = "Map";
             document.getElementById("t_track_infos").innerHTML = "Load track infos (dashboard restart needed)";

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1416,8 +1416,8 @@ var controller = function () {
                         + recordRaceFields(race, r)
                         + Util.gentd("Position","",null, (r.pos ? Util.formatPosition(r.pos.lat, r.pos.lon) : "-") )
                         + Util.gentd("Options","",xOptionsTitle, xOptionsTxt)
-                        + Util.gentd("State",null, 'title="' + txtTitle + '"', iconState )
-                        + Util.gentd("Remove", "", null, (r.choice && uid != currentUserId ? '<span class="removeSelectedBoat" data-id="' + uid + '" title="Remove this boat">❌</span>' : ""), false)
+                        + Util.gentd("State", "", txtTitle, iconState)
+                        + Util.gentd("Remove", "", null, (r.choice && uid != currentUserId ? '<span class="removeSelectedBoat" data-id="' + uid + '" title="Remove this boat">❌</span>' : ""))
                         + '</tr>';
                 }
             }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1454,9 +1454,9 @@ var controller = function () {
 
         function tableHeader() {
             return '<tr>'
-                + '<th>' + "Time" + dateUTC() + '</th>'
+                + Util.genthRacelog("th_rl_date", "dateTime", "Time" + dateUTC())
                 + commonHeaders()
-                + '<th title="Auto Sail time remaining">' + "aSail" + '</th>'
+                + Util.genthRacelog("th_rl_aSail", "aSail", "aSail", "Auto Sail time remaining")
                 + Util.genthRacelog("th_rl_reportedSpeed", "reportedSpeed", "vR (kn)", "Reported speed")
                 + Util.genthRacelog("th_rl_calcSpeed", "calcSpeed", "vC (kn)", "Calculated speed (Δd/Δt)")
                 + Util.genthRacelog("th_rl_foils", "foils", "Foils", "Foiling factor")
@@ -1465,9 +1465,9 @@ var controller = function () {
                 + Util.genthRacelog("th_rl_deltaDistance", "deltaDistance", "Δd (nm)", "Calculated distance")
                 + Util.genthRacelog("th_rl_deltaTime", "deltaTime", "Δt (s)", "Time between positions")
                 + Util.genthRacelog("th_rl_psn", "position", "Position")
-                + '<th title="Sail change time remaining">' + "Sail" + '</th>'
-                + '<th title="Gybing time remaining">' + "Gybe" + '</th>'
-                + '<th title="Tacking time remaining">' + "Tack" + '</th>'
+                + Util.genthRacelog("th_rl_sail", "sail", "Sail", "Sail change time remaining")
+                + Util.genthRacelog("th_rl_gybe", "gybe", "Gybe", "Gybing time remaining")
+                + Util.genthRacelog("th_rl_tack", "tack", "Tack", "Tacking time remaining")
                 + '</tr>';
         }
 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -5071,15 +5071,15 @@ async function initializeMap(race) {
             document.getElementById("t_auto_clean").innerHTML = "Nettoyage infos obsolètes";
             
             document.getElementById("t_config_c").innerHTML = "Colonnes";
-            document.getElementById("t_fleet_team").innerHTML = "Team";
-            document.getElementById("t_fleet_rank").innerHTML = "Rank";
-            document.getElementById("t_fleet_racetime").innerHTML = "Race Time";
-            document.getElementById("t_fleet_speed").innerHTML = "Speed";
-            document.getElementById("t_fleet_sail").innerHTML = "Sail";
+            document.getElementById("t_fleet_team").innerHTML = "Équipe";
+            document.getElementById("t_fleet_rank").innerHTML = "Rang";
+            document.getElementById("t_fleet_racetime").innerHTML = "Temps de course";
+            document.getElementById("t_fleet_speed").innerHTML = "Vitesse";
+            document.getElementById("t_fleet_sail").innerHTML = "Voile";
             document.getElementById("t_fleet_factor").innerHTML = "Factor";
             document.getElementById("t_fleet_position").innerHTML = "Position";
             document.getElementById("t_fleet_options").innerHTML = "Options";
-            document.getElementById("t_fleet_state").innerHTML = "State";
+            document.getElementById("t_fleet_state").innerHTML = "État";
 
             document.getElementById("t_racelog_position").innerHTML = "Position";
             document.getElementById("t_racelog_stamina").innerHTML = "Stamina";

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -3544,7 +3544,7 @@ function buildlogBookHTML(race) {
     var raceIdentification = '<table id="raceidTable">'
         + '<thead>'
         + '<tr>'
-        + '<th colspan = 8>' + race.legdata.name + ' (' + race.id + ') VSR' + race.legdata.vsrLevel/*race.legdata.priceLevel*/ + ' ' + race.legdata.boat.name+' ' + determineRankingCategory(playerOption) + '</th>'
+        + '<th colspan = 8>' + race.legdata.name + ' (' + race.id + ') • VSR' + race.legdata.vsrLevel/*race.legdata.priceLevel*/ + ' • ' + race.legdata.boat.name + ' • ' + determineRankingCategory(playerOption) + ' • GFS ' + race.gfsWinds + '</th>'
         + '</tr>' 
         + '</thead>'
         + '</table>'
@@ -4455,6 +4455,9 @@ async function initializeMap(race) {
             race.record = legInfo.record;
             if (legInfo.problem == "badSail") {} else if (legInfo.problem == "...") {}
         
+            race.gfsWinds = '1.0';
+            if (legInfo.fineWinds && legInfo.fineWinds === true) race.gfsWinds = '0.25';
+
             var raceData = DM.getRaceInfos(rid);
             if(!raceData|| raceData.raceType == DM.raceInfosModel.raceType)
             {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1438,6 +1438,7 @@ var controller = function () {
             divFriendList.innerHTML = fleetHTML;
 
             addEventListenersToRemoveSelectedBoatButtons();
+            addEventListenersToSelectedLine();
         }
     }
 
@@ -3867,6 +3868,20 @@ async function initializeMap(race) {
         var fleet = raceFleetMap.get(race.id);
         fleet.uinfo[boatId].choice = false;
         updateFleetHTML(raceFleetMap.get(selRace.value));
+    }
+
+    function addEventListenersToSelectedLine() {
+        document.querySelectorAll("tr.hovred").forEach(function(row) {
+            row.addEventListener("click", function() {
+                row.classList.add("selectedLine");
+                var siblings = Array.from(row.parentNode.children).filter(function(child) {
+                    return child !== row && child.classList.contains("hovred");
+                });
+                siblings.forEach(function(sibling) {
+                    sibling.classList.remove("selectedLine");
+                });
+            });
+        });
     }
 
     function addConfigListeners() {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1962,6 +1962,26 @@ var controller = function () {
         if(document.getElementById("ITYC_record").checked) tr.addInfoFleet(uid,storedInfo,race.type);
     }
 
+    function mergeBoatTrackInfo(rid, uid, data) {
+        var fleet = raceFleetMap.get(rid);
+        if (!fleet) {
+            console.log("raceInfo not initialized");
+            return;
+        }
+        var storedInfo = fleet.uinfo[uid];
+        if (!storedInfo) {
+            storedInfo = new Object();
+            fleet.uinfo[uid] = storedInfo;
+            fleet.table.push(uid);
+        }
+        // copy elems from data to uinfo
+        elemList.forEach( function (tag) {
+            if (tag in data && data[tag]) {
+                storedInfo[tag] = data[tag];
+            }
+        });
+    }
+
     function fixMessageData (message, userId) {
 
         if (message.type == "pilotBoat") {
@@ -4208,6 +4228,8 @@ async function initializeMap(race) {
                     if (message.track._id.user_id == currentUserId) {
                         handleOwnTrackInfo(message.track);
                     } else {
+                        mergeBoatTrackInfo(raceId, message.bs._id.user_id, message.track);
+                        lMap.updateMapFleet(race,raceFleetMap);
                         // Ignore track info.
                         // There is currently no function to update a single competitor track.
                     }
@@ -4634,7 +4656,7 @@ async function initializeMap(race) {
                 
                 var race = races.get(raceId);
                 lMap.updateMapFleet(race,raceFleetMap);
-                updateMapFleet(race);
+                //updateMapFleet(race);
                 rt.updateFleet(race,raceFleetMap);
             }
         }
@@ -4698,7 +4720,7 @@ async function initializeMap(race) {
         var raceId = getRaceLegId(request);
         var race = races.get(raceId);
         updateFleet(raceId, "followed", response.scriptData.res);
-        updateMapFleet(race);
+        //updateMapFleet(race);
         lMap.updateMapFleet(race,raceFleetMap);
         rt.updateFleet(race,raceFleetMap);
         if (raceId == selRace.value) {
@@ -4710,7 +4732,7 @@ async function initializeMap(race) {
         var raceId = getRaceLegId(request);
         var race = races.get(raceId);
         updateFleet(raceId, "opponents", response.scriptData.res);
-        updateMapFleet(race);
+        //updateMapFleet(race);
         lMap.updateMapFleet(race,raceFleetMap);
         rt.updateFleet(race,raceFleetMap);
         if (raceId == selRace.value) {

--- a/js/map.js
+++ b/js/map.js
@@ -1263,6 +1263,7 @@ function importRoute(route,race,name) {
     lmapRoute.displayedName = route.displayedName;
 
     lmapRoute.projectionData = [];
+    let currentSail = '';
     for (var i = 0 ; i < route.points.length ; i++) {
         var pos = buildPt2(route.points[i].lat, route.points[i].lon);
 
@@ -1270,7 +1271,15 @@ function importRoute(route,race,name) {
         
         lmapRoute.projectionData.push(createProjectionPoint(route.points[i].timestamp,route.points[i].lat, route.points[i].lon)); 
 
-        buildCircle(pos, lmapRoute.markersLayer,lmapRoute.color, 2,1,rt.buildMarkerTitle(route.points[i]));
+        let circleSize = 2;
+        let circleColor = lmapRoute.color;
+        if (currentSail != route.points[i].sail) {
+            if (currentSail != '') {
+                circleColor = rt.darkenColor(lmapRoute.color, 110);
+            }
+            currentSail = route.points[i].sail;
+        }
+        buildCircle(pos, lmapRoute.markersLayer, circleColor, circleSize, 1, rt.buildMarkerTitle(route.points[i]));
 
         
     }

--- a/js/routingviewer.js
+++ b/js/routingviewer.js
@@ -760,6 +760,26 @@ function buildMarkerTitle(point)
 
 }
 
+function darkenColor(hexColor, amount) {
+    const color = hexColor.replace("#", "");
+    // Extract RGB comp.
+    const r = parseInt(color.substring(0, 2), 16);
+    const g = parseInt(color.substring(2, 4), 16);
+    const b = parseInt(color.substring(4, 6), 16);
+    // Calculer les nouvelles valeurs RVB avec une luminosité réduite
+    const darkenedR = Math.max(0, r - amount);
+    const darkenedG = Math.max(0, g - amount);
+    const darkenedB = Math.max(0, b - amount);
+
+    // Convertir les nouvelles valeurs RVB en format hexadécimal
+    const darkenedHexColor = `#${componentToHex(darkenedR)}${componentToHex(darkenedG)}${componentToHex(darkenedB)}`;
+    return darkenedHexColor;
+}
+function componentToHex(component) {
+    const hex = component.toString(16);
+    return hex.length === 1 ? "0" + hex : hex;
+}
+
 function displayMapTrace(race,routeName)
 {
     var route = getRoute(race.id,routeName);
@@ -789,6 +809,7 @@ function help(){
 export {
     initialize,routeInfosmodel,createEmptyRoute,addNewPoints,getRoute,routeExists,
     myRoute,updateRouteListHTML,onRouteListClick,buildMarkerTitle,displayMapTrace,onCleanRoute,onMarkersChange,onAddRouteLmap,
-    initializeWebInterface,updateFleet,updateRaces,set_nbdigit,set_displayFilter,set_currentId
+    initializeWebInterface,updateFleet,updateRaces,set_nbdigit,set_displayFilter,set_currentId,
+    darkenColor
 
 };

--- a/js/routingviewer.js
+++ b/js/routingviewer.js
@@ -771,21 +771,17 @@ function displayMapTrace(race,routeName)
 
 // Help for import
 function help(){
-    var msg = "Affichage des trait de cotes :\n" +
-        "- zoomer sur la zone de la carte où vous souhaitez afficher les traits de cotes\n" +
-        "- Attendez quelques instants \n" +
-        "- La couleur des traits de cotes peut être personnalisé (Selection couleur côtes)\n" + 
-        " - Si vous souhaitez afficher une zone différente\n" +
-        " - Dézoomez et zommez à l endroit désiré\n\n" +
+    var msg = "Affichage des traits de côtes :\n" +
+        "- Zoomer sur la zone de la carte où vous souhaitez afficher les traits de côtes. Attendez quelques instants. Ils apparaissent automatiquement en bleu.\nLa couleur des traits de côtes peut être personnalisée (Sélection couleur 'Côtes')\nSi vous souhaitez afficher une zone différente, dézoomez et zommez à l'endroit désiré.\n\n" + 
         "Import Zezo :\n" +
-        "- Importe la route en cours sur votre onglet zezo.\n" +
-        "- Si vous modifiez le paramétrage de votre route zezo (destination, profondeur des prévisions...), cliquez sur la roue de la colonne RT avant d'importer.\n\n" +
+        "- Importer la route en cours suggéré par Zezo.\n" +
+        "- Si vous modifiez le paramétrage de votre route Zezo (destination, profondeur des prévisions...), cliquez sur la roue de la colonne \"RT\" avant d'importer.\n\n" +
         "Import Avalon :\n" +
         "- Depuis votre logiciel Avalon, exportez votre route au format CSV et importez le.\n\n" +
         "Import VRZen :\n" +
         "- Depuis le routeur VRZen, exportez votre route au format CSV et importez le.\n\n" +
         "Import GPX :\n" +
-        "- Importez le!\n\n";
+        "- Importez le !";
         
     alert(msg);
 }


### PR DESCRIPTION
- Fixed the problem of tracks not being displayed when the boat has been selected/clicked on.
- Added display of sail changes on imported routings by a marker darker than the others on the "Map" tab.
- Added information about the wind resolution model chosen for the race in the "Racebook" tab.
- Added the ability to visually select a line by clicking on it (add a yellow border) in the "Fleet" tab. Convenient for easy comparison of the selected line with another.
- Correction of date display for lines corresponding to commands in the "Racelog" tab.
- Fixed dimensions of certain fixed-width columns in the "Racelog" tab.
- Correction of some English-to-French translations.
- Correction of an old missing modification including new additions.
- Adjust option to hide "Command/Actions" lines to keep only the last 3.
- Correction of an old missing modification about columns titles display.
- Correction of visible white background with dark theme.