### PR TITLE
Safer fetch

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -129,39 +129,39 @@
                 <ul class="tab2">
                     <li class="tab">
                         <input type="checkbox" id="sel_team" name="checkbox1" class="content hidden" checked>
-                        <label for:"sel_team" id="lbl_team"><span style="color:Red;">&#x2B24;</span>&nbsp;Team</label>
+                        <label for="sel_team" id="lbl_team"><span style="color:Red;">&#x2B24;</span>&nbsp;Team</label>
                     </li>
                     <li class="tab">
                         <input type="checkbox" id="sel_friends" name="checkbox2" class="content hidden" checked>
-                        <label for:"sel_friends" id="lbl_friends"><span style="color:LimeGreen;">&#x2B24;</span>&nbsp;Amis</label>
+                        <label for="sel_friends" id="lbl_friends"><span style="color:LimeGreen;">&#x2B24;</span>&nbsp;Amis</label>
                     </li>
                     <li class="tab">
                         <input type="checkbox" id="sel_top" name="checkbox3" class="content hidden" checked>
-                        <label for:"sel_top" id="lbl_top"><span style="color:GoldenRod;">&#x2B24;</span>&nbsp;Top VSR</label>
+                        <label for="sel_top" id="lbl_top"><span style="color:GoldenRod;">&#x2B24;</span>&nbsp;Top VSR</label>
                     </li>
                     <li class="tab">
                         <input type="checkbox" id="sel_sponsors" name="checkbox4" class="content hidden" checked>
-                        <label for:"sel_sponsors" id="lbl_sponsors"><span style="color:DarkSlateBlue;">&#x2B24;</span>&nbsp;Sponsors</label>
+                        <label for="sel_sponsors" id="lbl_sponsors"><span style="color:DarkSlateBlue;">&#x2B24;</span>&nbsp;Sponsors</label>
                     </li>
                     <li class="tab">
                         <input type="checkbox" id="sel_certified" name="checkbox5" class="content hidden" checked>
-                        <label for:"sel_certified" id="lbl_certified"><span style="color:DodgerBlue;">&#x2B24;</span>&nbsp;Certifié</label>
+                        <label for="sel_certified" id="lbl_certified"><span style="color:DodgerBlue;">&#x2B24;</span>&nbsp;Certifié</label>
                     </li>
                     <li class="tab">
                         <input type="checkbox" id="sel_opponents" name="checkbox6" class="content hidden">
-                        <label for:"sel_opponents" id="lbl_opponents"><span style="color:lightgray;">&#x2B24;</span>&nbsp;Adversaires</label>
+                        <label for="sel_opponents" id="lbl_opponents"><span style="color:lightgray;">&#x2B24;</span>&nbsp;Adversaires</label>
                     </li>
                     <li class="tab">
                         <input type="checkbox" id="sel_reals" name="checkbox7" class="content hidden">
-                        <label for:"sel_reals" id="lbl_reals"><span style="color:Chocolate;">&#x2B24;</span>&nbsp;Réels</label>
+                        <label for="sel_reals" id="lbl_reals"><span style="color:Chocolate;">&#x2B24;</span>&nbsp;Réels</label>
                     </li>
                     <li class="tab">
                         <input type="checkbox" id="sel_selected" name="checkbox8" class="content hidden" checked>
-                        <label for:"sel_selected" id="lbl_selected"><span style="color:HotPink;">&#x2B24;</span>&nbsp;Sélectionné</label>
+                        <label for="sel_selected" id="lbl_selected"><span style="color:HotPink;">&#x2B24;</span>&nbsp;Sélectionné</label>
                     </li>
                     <li class="tab">
                         <input type="checkbox" id="sel_inrace" name="checkbox9" class="content hidden">
-                        <label for:"sel_inrace" id="lbl_inrace">En course</label>
+                        <label for="sel_inrace" id="lbl_inrace">En course</label>
                     </li>
                 </ul>
             </fieldset>
@@ -179,29 +179,29 @@
         <div id="mapfilterLmap">
             <div id="extraLmap" class="mapBtDiv">
                 <input type="button" id="sel_helpLmap" name="button4" checked class="content hidden">
-                <label for:"sel_helpLmap" id="lbl_helpLmap">Aide</label>
+                <label for="sel_helpLmap" id="lbl_helpLmap">Aide</label>
             </div>
             <div class="extraMapSep"></div>
             <div id="existingRouteLmap" class="mapBtDiv mapPrevSep">
                 <input type="checkbox" id="sel_showMarkersLmap" name="button12" class="content hidden">
-                <label for:"sel_showMarkersLmap" id="lbl_showMarkersLmap">Marqueurs</label>
+                <label for="sel_showMarkersLmap" id="lbl_showMarkersLmap">Marqueurs</label>
                 <input type="checkbox" id="sel_showTracksLmap" name="button12" class="content hidden">
-                <label for:"sel_showTracksLmap" id="lbl_showTracksLmap">Traces</label>
+                <label for="sel_showTracksLmap" id="lbl_showTracksLmap">Traces</label>
             </div>
             <div class="extraMapSep"></div>
             <div id="existingRoute2Lmap" class="mapBtDiv">
                 <input type="checkbox" id="sel_rt_openLmap" name="button12" class="content hidden">
-                <label for:"sel_rt_openLmap" id="lbl_rt_openLmap">Ajouter</label>
+                <label for="sel_rt_openLmap" id="lbl_rt_openLmap">Ajouter</label>
                 <input type="button" id="sel_rt_cleanLmap" name="button4" checked class="content hidden">
-                <label for:"sel_rt_cleanLmap" id="lbl_rt_cleanLmap">Effacer</label>
+                <label for="sel_rt_cleanLmap" id="lbl_rt_cleanLmap">Effacer</label>
             </div>
             <div id="existingRoute3Lmap" class="mapBtDiv mapPrevSep">
                 <div class="rt_lst_color">
-                    <label for:"sel_borderColorLmap" id="lbl_borderColorLmap">Cotes</label>
+                    <label for="sel_borderColorLmap" id="lbl_borderColorLmap">Cotes</label>
                     <input type="color"id="sel_borderColorLmap" value="#0000FF" >
                 </div>
                 <div class="rt_lst_color">
-                    <label  for:"sel_projectionColorLmap" id="lbl_projectionColorLmap">Projection</label>
+                    <label  for="sel_projectionColorLmap" id="lbl_projectionColorLmap">Projection</label>
                     <input type="color"id="sel_projectionColorLmap" value="#0000FF" >   
                 </div>
             </div>


### PR DESCRIPTION
- Account for the fact `fetch` can be called with `fetch(init)` (including `url` in config) or `fetch(url, init)`
- Earlier exits and hoisting up conditions from `handleResponse` to avoid piggybacking on HTTP responses when there isn't the need to
- Account for more possible body types (`object` or `string` as well as `blob`)
- Avoid single `try / catch` which could lead to failed requests being performed twice
- Removed old `xhr` monkey path
- Using new `chrome.runtime.sendMessage` signature
- Don't handle requests without a body
- Don't forward `password` and `username` (user emails) to the dashboard