### PR TITLE
nmea: append last validated gate group to $IIVWR sentence

### DIFF
--- a/js/nmea.js
+++ b/js/nmea.js
@@ -19,6 +19,10 @@ var settings = {
 
 var running = false;
 
+// Last seen VR gateGroupCounters (boatinfo messages don't all include it).
+// Memoized + reset on race change so every $IIVWR can carry the gate field once known.
+var lastGateCounters = null;
+
 var crcTable = makeCRCTable();
 
 var nmeaTimer;
@@ -27,6 +31,7 @@ var activeRace;
 function setActiveRace(rid)
 {
     activeRace = rid;
+    lastGateCounters = null; // forget the previous race's gate counters
     settings.nmeaRetry = 0;
     settings.nmeaInterval = NMEA_DELAY;
 }
@@ -226,6 +231,18 @@ function formatIIVWR (m) {
     s += "," + awside;
     s += "," + aws.toFixed(5) + ",N";
     s += ",,,,";
+    // Proprietary trailing field: last validated gate group (1-based; 0 = none).
+    // gateGroupCounters[i] is the counter for group i+1 (same indexing as the
+    // dash's gatecnt[group-1]); lastGate = highest group with a non-zero counter.
+    // Memoized at module scope (reset on race change) so EVERY VWR carries the field
+    // once known: a consumer reads a VWR *without* the field as "no longer provided",
+    // so an intermittent field would make it toggle. Ignored by standard VWR readers.
+    if (Array.isArray(m.gateGroupCounters)) lastGateCounters = m.gateGroupCounters;
+    if (Array.isArray(lastGateCounters)) {
+        var lastGate = 0;
+        for (var i = 0; i < lastGateCounters.length; i++) { if (lastGateCounters[i] > 0) lastGate = i + 1; }
+        s += "," + lastGate;
+    }
     return s;
 }
 


### PR DESCRIPTION
## What

Append a proprietary trailing field to the `$IIVWR` sentence carrying the **last validated gate group** (1-based; `0` = none), derived from VR's `gateGroupCounters`.

`gateGroupCounters[i]` is the counter for group `i+1` (same indexing as the dash's `gatecnt[group-1]`); `lastGate` is the highest group with a non-zero counter.

## Why

`boatinfo` messages don't all include `gateGroupCounters`, so the value is **memoized at module scope** and **reset on race change** (`setActiveRace`). This guarantees that *every* `$IIVWR` carries the field once it is known.

A consumer reads a VWR *without* the field as "no longer provided", so emitting it intermittently would make the value toggle — memoization avoids that. The extra trailing field is ignored by standard VWR readers, so this is backward-compatible.

## Changes

- `js/nmea.js`: add module-scope `lastGateCounters` (reset in `setActiveRace`), and emit the `lastGate` field at the end of `formatIIVWR`.

Single file, +17 lines, no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
